### PR TITLE
Support copying over (some) `@rpath` and `@loader_path` prefixed libs

### DIFF
--- a/dylib-capture-closure
+++ b/dylib-capture-closure
@@ -87,6 +87,27 @@ module DylibCaptureClosure
 
       libs.delete(library_id) if library_id
 
+      previous_lib = nil
+      original_lib = libs.first
+      libs.map! do |lib|
+        if lib.start_with?('@rpath') || lib.start_with?('@loader_path')
+          lib_name = File.basename(lib)
+
+          previous_lib_dir = File.dirname(previous_lib)
+          original_lib_dir = File.dirname(original_lib)
+
+          if File.exist?(File.join(previous_lib_dir, lib_name))
+            lib = File.join(previous_lib_dir, lib_name)
+          elsif File.exist?(File.join(original_lib_dir, lib_name))
+            lib = File.join(original_lib_dir, lib_name)
+          else
+            print("could not find #{lib_name} in #{previous_lib_dir} or #{original_lib_dir}, just carry on")
+          end
+        end
+
+        previous_lib = lib
+      end
+
       # reject dylibs that already point inside the closure, and those that point to /usr/lib.
       libs.reject! do |lib|
         lib = File.expand_path(lib) # maybe unnecessary?


### PR DESCRIPTION
Needed for https://github.com/Shopify/dev/issues/9965

When capturing libs for building `imagery4`, I got a few errors for libs that were prefixed with `@rpath` and `@loader_path`.

These prefixes are special placeholders used in macOS for specifying runtime library search paths. Looking at the instances where it happened, it meant the same directory of the library just being loaded. Maybe there are other cases I haven't come across? It doesn't matter, as this code just tries a best attempt to fix these scenarios.

```
$ otool -l /opt/homebrew/opt/protobuf/lib/libprotobuf.28.1.0.dylib | grep '@rpath'
         name @rpath/libutf8_validity.dylib (offset 24)

➜  shopify git:(main) ls -lh /opt/homebrew/opt/protobuf/lib | grep libutf8_validity
-r--r--r--  1 gabrielparreiras  admin    35K 27 Sep 13:55 libutf8_validity.dylib
```

It could also happen that an indirectly referenced lib then uses `@rpath`/`@loader_path`, that's why I used the `previous_lib` construct.