### PR TITLE
Update LC_RPATH on libs that use @rpath

### DIFF
--- a/dylib-capture-closure
+++ b/dylib-capture-closure
@@ -37,7 +37,7 @@ module DylibCaptureClosure
       obj.relink(stage, prefix)
     end
 
-    attr_reader(:object, :library_id, :dylibs)
+    attr_reader(:object, :library_id, :dylibs, :rpath)
 
     def initialize(object)
       raise(NotAnObject, '', []) if File.directory?(object)
@@ -53,6 +53,7 @@ module DylibCaptureClosure
       @object     = object
       @library_id = nil
       @dylibs     = []
+      @rpath      = nil
 
       # `out` looks something like this for an executable:
       #
@@ -90,6 +91,19 @@ module DylibCaptureClosure
       previous_lib = nil
       original_lib = libs.first
       libs.map! do |lib|
+        if lib.start_with?('@rpath') && rpath.nil?
+          l_out, stat = Open3.capture2e('otool', '-l', object)
+          abort("otool -l failed:\n#{out}") unless stat.success?
+
+          rpath_header_index = l_out.lines.index { |l| l =~ /LC_RPATH/ }
+          abort("can't find LC_RPATH for #{object}: #{out}") if rpath_header_index.nil?
+
+          rpath_line = l_out.lines[rpath_header_index..(rpath_header_index + 2)].find { |l| l =~ /path/ }
+          abort("can't find LC_RPATH path value for #{object}: #{out}") if rpath_line.nil?
+
+          @rpath = rpath_line.split(' ')[1]
+        end
+
         if lib.start_with?('@rpath') || lib.start_with?('@loader_path')
           lib_name = File.basename(lib)
 
@@ -146,12 +160,18 @@ module DylibCaptureClosure
         target_object.relink(stage, prefix, inset: inset + 2)
       end
 
+      change_rpath(File.join(prefix, LIB_CLOSURE)) unless rpath.nil?
       change_codesign()
     end
 
     def change_library_id(target)
       _, stat = Open3.capture2('install_name_tool', '-id', target, object)
       abort('install_name_tool -id failed') unless stat.success?
+    end
+
+    def change_rpath(target)
+      _, stat = Open3.capture2('install_name_tool', '-rpath', rpath, target, object)
+      abort('install_name_tool -rpath failed') unless stat.success?
     end
 
     def change_codesign()


### PR DESCRIPTION
Follow-up from https://github.com/Shopify/dylib-capture-closure/pull/8

The previous PR implemented finding and copying over libs referenced with `@rpath`.
But some libs that use `@rpath`, also define `LC_RPATH` as absolute paths on the system; meaning that the copied libs in `lib.closure` were not being used.

On [this comment](https://github.com/Shopify/dev/pull/9987#pullrequestreview-2342365312), we see the error:
```
Referenced from: <70A83CDE-CBEE-33BA-A8FD-BD32903982A9> /opt/dev/vendor/packages/imagery4/lib.closure/libopencv_imgproc.410.dylib                         
Reason: tried: '/opt/homebrew/Cellar/opencv/4.10.0_6/lib/libopencv_core.410.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/open
/Users/dbl/.local/run/services/shared/imagery4/run.sh: line 14: 71034 Abort trap: 6           /opt/dev/vendor/packages/imagery4/we
```

Debugging:
```
$ otool -L libopencv_imgproc.410.dylib
libopencv_imgproc.410.dylib:
	/opt/dev/vendor/packages/imagery4/lib.closure/libopencv_imgproc.410.dylib (compatibility version 410.0.0, current version 4.10.0)
	@rpath/libopencv_core.410.dylib (compatibility version 410.0.0, current version 4.10.0)
...

$ otool -l libopencv_imgproc.410.dylib
...
Load command 18
          cmd LC_RPATH
      cmdsize 56
         path /opt/homebrew/Cellar/opencv/4.10.0_6/lib (offset 12)
```

`libopencv_core.410.dylib` was copied over to `lib.closure`. The problem is just that it's referenced within its original absolute path (`/opt/homebrew/Cellar/opencv/4.10.0_6/lib/libopencv_core.410.dylib`).

The idea of this PR is to update `LC_RPATH` for captured libs that use `@rpath` on their references. `LC_RPATH` should now point at the `lib.closure` path.